### PR TITLE
Clean up audio upload

### DIFF
--- a/AbleSync.Core/Constants.cs
+++ b/AbleSync.Core/Constants.cs
@@ -34,11 +34,15 @@
                 AudioFlacFileExtension
             };
 
-        // TODO Implement structure.
         /// <summary>
-        ///     Project folders storage base folder..
+        ///     Project folders storage folder name.
         /// </summary>
         public const string StorageProjectFolderBase = "projects";
+
+        /// <summary>
+        ///     Audio file storage folder name.
+        /// </summary>
+        public const string StorageAudioFilesFolder = "audiofiles";
 
         public const string ContentTypeMp3 = "audio/mpeg3";
 

--- a/AbleSync.Core/Entities/AudioFile.cs
+++ b/AbleSync.Core/Entities/AudioFile.cs
@@ -33,5 +33,9 @@ namespace AbleSync.Core.Entities
         /// </summary>
         public DateTimeOffset? DateUpdated { get; set; }
 
+        /// <summary>
+        ///     Latest sync time.
+        /// </summary>
+        public DateTimeOffset DateSynced { get; set; }
     }
 }

--- a/AbleSync.Core/Helpers/DirectoryInfoHelper.cs
+++ b/AbleSync.Core/Helpers/DirectoryInfoHelper.cs
@@ -27,12 +27,32 @@ namespace AbleSync.Core.Helpers
                 throw new ArgumentNullException(nameof(project));
             }
 
+            return new DirectoryInfo(ParsePathFromProject(rootDirectory, project));
+        }
+
+        /// <summary>
+        ///     Parses a project path.
+        /// </summary>
+        /// <param name="rootDirectory">The ablesync root.</param>
+        /// <param name="project">The project to parse.</param>
+        /// <returns>The full path string, escaped.</returns>
+        public static string ParsePathFromProject(Uri rootDirectory, Project project)
+        {
+            if (rootDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(rootDirectory));
+            }
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
             // TODO Beun, see https://github.com/tabeckers/AbleSync/issues/19
             var parsedPath = project.RelativePath.Replace("\\", "/", StringComparison.InvariantCulture);
             var path = $"{rootDirectory.AbsolutePath}/{parsedPath}";
             path = path.Replace("%20", " ", StringComparison.InvariantCulture);
 
-            return new DirectoryInfo(path);
+            return path;
         }
     }
 }

--- a/AbleSync.Core/Helpers/FileStorageHelper.cs
+++ b/AbleSync.Core/Helpers/FileStorageHelper.cs
@@ -1,0 +1,36 @@
+﻿using RenameMe.Utility.Extensions;
+using System;
+
+namespace AbleSync.Core.Helpers
+{
+    /// <summary>
+    ///     Contains centralized functionality with regards
+    ///     to file storage and file names.
+    /// </summary>
+    public static class FileStorageHelper
+    {
+        /// <summary>
+        ///     Generates the filename of an audio file based on 
+        ///     the audio file id.
+        /// </summary>
+        /// <param name="audioFileId">The audio file id.</param>
+        /// <returns>The storage file name.</returns>
+        public static string AudioFileName(Guid audioFileId)
+        {
+            audioFileId.ThrowIfNullOrEmpty();
+            return $"{audioFileId}";
+        }
+
+        /// <summary>
+        ///     Generates the audio file folder name based on
+        ///     a given project id.
+        /// </summary>
+        /// <param name="projectId">The project id.</param>
+        /// <returns>The audio file folder name for the project.</returns>
+        public static string AudioFileFolder(Guid projectId)
+        {
+            projectId.ThrowIfNullOrEmpty();
+            return $"{Constants.StorageProjectFolderBase}/{projectId}/{Constants.StorageAudioFilesFolder}";
+        }
+    }
+}

--- a/AbleSync.Core/Interfaces/Repositories/IAudioFileRepository.cs
+++ b/AbleSync.Core/Interfaces/Repositories/IAudioFileRepository.cs
@@ -1,0 +1,54 @@
+﻿using AbleSync.Core.Entities;
+using AbleSync.Core.Types;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AbleSync.Core.Interfaces.Repositories
+{
+    /// <summary>
+    ///     Repository for audio files.
+    /// </summary>
+    public interface IAudioFileRepository : IRepositoryBaseCRUD<AudioFile>
+    {
+        /// <summary>
+        ///     Checks if any audio files exist for a given 
+        ///     project id.
+        /// </summary>
+        /// <param name="projectId">The project id.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns><c>True</c> if any audio file exists.</returns>
+        Task<bool> ExistsAnyForProjectAsync(Guid projectId, CancellationToken token);
+
+        /// <summary>
+        ///     Checks if an audio file in a specific audio format
+        ///     exists for a given project id.
+        /// </summary>
+        /// <param name="projectId">The project id.</param>
+        /// <param name="format">The audio format to check for.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns><c>True</c> if an audio file exists.</returns>
+        Task<bool> ExistsForProjectAsync(Guid projectId, AudioFormat format, CancellationToken token);
+
+        /// <summary>
+        ///     Gets an audio file for a given project and a
+        ///     given audio format.
+        /// </summary>
+        /// <remarks>
+        ///     The audio file should exist or this will throw
+        ///     an exception.
+        /// </remarks>
+        /// <param name="projectId">The project id.</param>
+        /// <param name="format">The format to get.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The audio file for the project and format.</returns>
+        Task<AudioFile> GetFromProjectAsync(Guid projectId, AudioFormat format, CancellationToken token);
+
+        /// <summary>
+        ///     Marks the sync date of an audio file as now.
+        /// </summary>
+        /// <param name="id">The audio file id.</param>
+        /// <param name="token">The cancellation token.</param>
+        Task MarkSyncedAsync(Guid id, CancellationToken token);
+    }
+}

--- a/AbleSync.Core/Interfaces/Repositories/IProjectRepository.cs
+++ b/AbleSync.Core/Interfaces/Repositories/IProjectRepository.cs
@@ -10,47 +10,8 @@ namespace AbleSync.Core.Interfaces.Repositories
     /// <summary>
     ///     Repository for Ableton projects.
     /// </summary>
-    public interface IProjectRepository
-    {
-        /// <summary>
-        ///     Creates a new <see cref="Project"/> in our data store.
-        /// </summary>
-        /// <param name="project">See <see cref="Project"/>.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>The created <see cref="Project"/>.</returns>
-        Task<Project> CreateAsync(Project project, CancellationToken token);
-
-        /// <summary>
-        ///     Deletes a project from our data store.
-        /// </summary>
-        /// <param name="id">Internal project id.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>See <see cref="Task"/>.</returns>
-        Task DeleteAsync(Guid id, CancellationToken token);
-
-        /// <summary>
-        ///     Checks if a given <see cref="Project"/> exists in our data store.
-        /// </summary>
-        /// <param name="id">Internal project id.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns><c>true</c> if the project exists.</returns>
-        Task<bool> ExistsAsync(Guid id, CancellationToken token);
-
-        /// <summary>
-        ///     Gets all <see cref="Project"/>s from our data store.
-        /// </summary>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>Collection of <see cref="Project"/>s.</returns>
-        IAsyncEnumerable<Project> GetAllAsync(CancellationToken token);
-
-        /// <summary>
-        ///     Gets a <see cref="Project"/> from our data store.
-        /// </summary>
-        /// <param name="id">Internal project id.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>The returned <see cref="Project"/>.</returns>
-        Task<Project> GetAsync(Guid id, CancellationToken token);
-
+    public interface IProjectRepository : IRepositoryBaseCRUD<Project>
+    { 
         /// <summary>
         ///     Marks a project as scraped by setting it's update date.
         /// </summary>
@@ -67,13 +28,5 @@ namespace AbleSync.Core.Interfaces.Repositories
         /// <param name="token">The cancellation token.</param>
         /// <returns>The <see cref="Project"/> after the status update.</returns>
         Task<Project> MarkProjectAsync(Guid id, ProjectStatus status, CancellationToken token);
-
-        /// <summary>
-        ///     Updates a <see cref="Project"/> in our data store.
-        /// </summary>
-        /// <param name="project">The new to-update <see cref="Project"/>.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>The updated <see cref="Project"/>.</returns>
-        Task<Project> UpdateAsync(Project project, CancellationToken token);
     }
 }

--- a/AbleSync.Core/Interfaces/Repositories/IProjectTaskRepository.cs
+++ b/AbleSync.Core/Interfaces/Repositories/IProjectTaskRepository.cs
@@ -10,23 +10,8 @@ namespace AbleSync.Core.Interfaces.Repositories
     /// <summary>
     ///     Repository for project tasks.
     /// </summary>
-    public interface IProjectTaskRepository
+    public interface IProjectTaskRepository : IRepositoryBaseCRUD<ProjectTask>
     {
-        /// <summary>
-        ///     Creates a new <see cref="ProjectTask"/> in our data store.
-        /// </summary>
-        /// <param name="projectTask">See <see cref="Project"/>.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>The created <see cref="ProjectTask"/>.</returns>
-        Task<ProjectTask> CreateAsync(ProjectTask projectTask, CancellationToken token);
-
-        /// <summary>
-        ///     Gets all the <see cref="ProjectTask"/> entities from our data store.
-        /// </summary>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>Collection of project tasks.</returns>
-        IAsyncEnumerable<ProjectTask> GetAllAsync(CancellationToken token);
-
         /// <summary>
         ///     Gets all <see cref="ProjectTask"/>s for a given <see cref="Project"/>.
         /// </summary>
@@ -34,14 +19,6 @@ namespace AbleSync.Core.Interfaces.Repositories
         /// <param name="token">The cancellation token.</param>
         /// <returns>Collection of <see cref="Project"/>s.</returns>
         IAsyncEnumerable<ProjectTask> GetAllForProjectAsync(Guid projectId, CancellationToken token);
-
-        /// <summary>
-        ///     Gets a <see cref="ProjectTask"/> from our data store.
-        /// </summary>
-        /// <param name="id">Internal project id.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>The returned <see cref="ProjectTask"/>.</returns>
-        Task<ProjectTask> GetAsync(Guid id, CancellationToken token);
 
         /// <summary>
         ///     Marks the status of a <see cref="ProjectTask"/>.

--- a/AbleSync.Core/Interfaces/Repositories/IRepositoryBaseCRUD.cs
+++ b/AbleSync.Core/Interfaces/Repositories/IRepositoryBaseCRUD.cs
@@ -1,0 +1,81 @@
+﻿using AbleSync.Core.Entities;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AbleSync.Core.Interfaces.Repositories
+{
+    /// <summary>
+    ///     Base interface for an entity repository.
+    /// </summary>
+    /// <typeparam name="TEntity"></typeparam>
+    public interface IRepositoryBaseCRUD<TEntity>
+        where TEntity : EntityBase
+    {
+        /// <summary>
+        ///     Creates an entity in our data store and returns
+        ///     the id of the created entity.
+        /// </summary>
+        /// <param name="entity">The entity to create.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The created entity id.</returns>
+        Task<Guid> CreateAsync(TEntity entity, CancellationToken token);
+
+        /// <summary>
+        ///     Creates an entity in our data store and gets
+        ///     it from the data store right after creation.
+        /// </summary>
+        /// <param name="entity">The entity to create.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The created entity.</returns>
+        Task<TEntity> CreateGetAsync(TEntity entity, CancellationToken token);
+
+        /// <summary>
+        ///     Deletes an entity from our data store.
+        /// </summary>
+        /// <param name="id">Internal entity id.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>See <see cref="Task"/>.</returns>
+        Task DeleteAsync(Guid id, CancellationToken token);
+
+        /// <summary>
+        ///     Checks if a given entity exists in our data store.
+        /// </summary>
+        /// <param name="id">Internal enitity id.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns><c>true</c> if the entity exists.</returns>
+        Task<bool> ExistsAsync(Guid id, CancellationToken token);
+
+        /// <summary>
+        ///     Gets all entities from our data store.
+        /// </summary>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>Collection of entities.</returns>
+        IAsyncEnumerable<TEntity> GetAllAsync(CancellationToken token);
+
+        /// <summary>
+        ///     Gets an entity from our data store.
+        /// </summary>
+        /// <param name="id">Internal entity id.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The returned entity.</returns>
+        Task<TEntity> GetAsync(Guid id, CancellationToken token);
+
+        /// <summary>
+        ///     Updates an entity in our data store.
+        /// </summary>
+        /// <param name="entity">The new to-update entity.</param>
+        /// <param name="token">The cancellation token.</param>
+        Task UpdateAsync(TEntity entity, CancellationToken token);
+
+        /// <summary>
+        ///     Updates an entity in our data store and returns 
+        ///     the enity from our data store right after.
+        /// </summary>
+        /// <param name="entity">The new to-update entity.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The updated entity as fetched from the data store.</returns>
+        Task<TEntity> UpdateGetAsync(TEntity entity, CancellationToken token);
+    }
+}

--- a/AbleSync.Core/ProjectTaskExecuters/UploadAudioExecuter.cs
+++ b/AbleSync.Core/ProjectTaskExecuters/UploadAudioExecuter.cs
@@ -93,13 +93,8 @@ namespace AbleSync.Core.ProjectTaskExecuters
                     ProjectId = project.Id
                 }, token);
 
-            // TODO Beun
-            var parsedPath = project.RelativePath.Replace("\\", "/", StringComparison.InvariantCulture);
-            var path = $"{_options.RootDirectoryPath.AbsolutePath}/{parsedPath}";
-            path = path.Replace("%20", " ", StringComparison.InvariantCulture);
-
             var fileNamePhysical = audioFilePhysical.Name;
-            var folderNamePhysical = $"{path}";
+            var folderNamePhysical = $"{DirectoryInfoHelper.ParsePathFromProject(_options.RootDirectoryPath, project)}";
             using var fileStream = new FileStream($"{folderNamePhysical}/{fileNamePhysical}", FileMode.Open, FileAccess.Read);
 
             var fileNameStorage = FileStorageHelper.AudioFileName(audioFileEntity.Id);

--- a/AbleSync.Core/ProjectTaskExecuters/UploadAudioExecuter.cs
+++ b/AbleSync.Core/ProjectTaskExecuters/UploadAudioExecuter.cs
@@ -1,4 +1,5 @@
 ﻿using AbleSync.Core.Entities;
+using AbleSync.Core.Helpers;
 using AbleSync.Core.Interfaces.Repositories;
 using AbleSync.Core.Interfaces.Services;
 using AbleSync.Core.Types;
@@ -18,6 +19,7 @@ namespace AbleSync.Core.ProjectTaskExecuters
     /// </summary>
     public class UploadAudioExecuter
     {
+        private readonly IAudioFileRepository _audioFileRepository;
         private readonly IProjectRepository _projectRepository;
         private readonly IBlobStorageService _blobStorageService;
         private readonly AbleSyncOptions _options;
@@ -26,21 +28,28 @@ namespace AbleSync.Core.ProjectTaskExecuters
         /// <summary>
         ///     Create new instance.
         /// </summary>
-        public UploadAudioExecuter(IProjectRepository projectRepository,
+        public UploadAudioExecuter(IAudioFileRepository audioFileRepository,
+            IProjectRepository projectRepository,
             IBlobStorageService blobStorageService,
             IOptions<AbleSyncOptions> options,
             ILogger<UploadAudioExecuter> logger)
         {
+            _audioFileRepository = audioFileRepository ?? throw new ArgumentNullException(nameof(audioFileRepository));
             _projectRepository = projectRepository ?? throw new ArgumentNullException(nameof(projectRepository));
             _blobStorageService = blobStorageService ?? throw new ArgumentNullException(nameof(blobStorageService));
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        // TODO Task isnt used?
+        // FUTURE Also support other audio formats.
+        // TODO This is windows coupled. See https://github.com/tabeckers/AbleSync/issues/19 and https://github.com/tabeckers/AbleSync/issues/28
+        // TODO Pick correct audio file, there may be multiple mp3 files.
         /// <summary>
         ///     Execute the upload for an audio file.
         /// </summary>
+        /// <remarks>
+        ///     This only handles mp3.
+        /// </remarks>
         /// <param name="task">The task.</param>
         /// <param name="token">The cancellation token.</param>
         public async Task ExecuteUploadAudioAsync(ProjectTask task, CancellationToken token)
@@ -58,54 +67,49 @@ namespace AbleSync.Core.ProjectTaskExecuters
                 throw new InvalidOperationException(nameof(task.ProjectTaskType));
             }
 
-            _logger.LogTrace($"Starting audio upload for project {task.ProjectId}");
+            _logger.LogTrace($"Starting mp3 audio upload for project {task.ProjectId}");
 
             var project = await _projectRepository.GetAsync(task.ProjectId, token);
+            var directoryInfo = DirectoryInfoHelper.GetFromProject(_options.RootDirectoryPath, project);
+            var audioFiles = directoryInfo.GetFiles().Where(x => Constants.ExportedAudioFileExtensions.Contains(x.Extension));
 
-            // TODO Beun, see https://github.com/tabeckers/AbleSync/issues/19
+            // TODO Do elegantly.
+            if (!audioFiles.Where(x => x.Extension == Constants.AudioMp3FileExtension).Any())
+            {
+                // TODO Custom exception.
+                throw new InvalidOperationException("Could not get mp3 file in project folder");
+            }
+
+            // Get the actual physical file because we need its name.
+            var audioFilePhysical = audioFiles.Where(x => x.Extension == Constants.AudioMp3FileExtension).First();
+
+            // Get or create the audio file.
+            var audioFileEntity = await _audioFileRepository.ExistsForProjectAsync(task.ProjectId, AudioFormat.Mp3, token)
+                ? await _audioFileRepository.GetFromProjectAsync(task.ProjectId, AudioFormat.Mp3, token)
+                : await _audioFileRepository.CreateGetAsync(new AudioFile
+                {
+                    AudioFormat = AudioFormat.Mp3,
+                    Name = audioFilePhysical.Name,
+                    ProjectId = project.Id
+                }, token);
+
+            // TODO Beun
             var parsedPath = project.RelativePath.Replace("\\", "/", StringComparison.InvariantCulture);
             var path = $"{_options.RootDirectoryPath.AbsolutePath}/{parsedPath}";
             path = path.Replace("%20", " ", StringComparison.InvariantCulture);
 
-            var directoryInfo = new DirectoryInfo(path);
+            var fileNamePhysical = audioFilePhysical.Name;
+            var folderNamePhysical = $"{path}";
+            using var fileStream = new FileStream($"{folderNamePhysical}/{fileNamePhysical}", FileMode.Open, FileAccess.Read);
 
-            var audioFiles = directoryInfo.GetFiles().Where(x => Constants.ExportedAudioFileExtensions.Contains(x.Extension));
+            var fileNameStorage = FileStorageHelper.AudioFileName(audioFileEntity.Id);
+            var folderNameStorage = FileStorageHelper.AudioFileFolder(project.Id);
+            await _blobStorageService.StoreFileAsync(folderNameStorage, fileNameStorage, Constants.ContentTypeMp3, fileStream, token);
 
-            // TODO Do elegantly.
-            var audioFile = null as FileInfo;
-            var contentType = "";
-            if (audioFiles.Where(x => x.Extension == Constants.AudioMp3FileExtension).Any())
-            {
-                audioFile = audioFiles.Where(x => x.Extension == Constants.AudioMp3FileExtension).First();
-                contentType = Constants.ContentTypeMp3;
-            }
-            else if (audioFiles.Where(x => x.Extension == Constants.AudioWavFileExtension).Any())
-            {
-                audioFile = audioFiles.Where(x => x.Extension == Constants.AudioWavFileExtension).First();
-                contentType = Constants.ContentTypeWav;
-            }
-            else if (audioFiles.Where(x => x.Extension == Constants.AudioFlacFileExtension).Any())
-            {
-                audioFile = audioFiles.Where(x => x.Extension == Constants.AudioFlacFileExtension).First();
-                contentType = Constants.ContentTypeFlac;
-            }
-            else
-            {
-                throw new InvalidOperationException("Could not get proper audio file.");
-            }
-
-            // This has the extension in it as well.
-            // TODO This is windows coupled. See https://github.com/tabeckers/AbleSync/issues/19 and https://github.com/tabeckers/AbleSync/issues/28
-            var fileName = $"{audioFile.Name}";
-            var directoryName = $"{Constants.StorageProjectFolderBase}/{project.Id}/{project.Name}.";
-            var fullFileName = $"{path}/{audioFile.Name}";
-
-            using var fileStream = new FileStream(fullFileName, FileMode.Open, FileAccess.Read);
-            await _blobStorageService.StoreFileAsync(directoryName, fileName, contentType, fileStream, token);
-
-            // TODO Here? https://github.com/tabeckers/AbleSync/issues/31
-            _logger.LogTrace($"Finished audio upload for project {task.ProjectId} - uploaded {fileName}");
+            // Mark our synchronization
+            await _audioFileRepository.MarkSyncedAsync(audioFileEntity.Id, token);
+            
+            _logger.LogTrace($"Finished mp3 audio upload for project {task.ProjectId} - uploaded {fileNamePhysical} as {fileNameStorage}");
         }
-
     }
 }

--- a/AbleSync.Core/Services/ProjectScrapingService.cs
+++ b/AbleSync.Core/Services/ProjectScrapingService.cs
@@ -170,9 +170,9 @@ namespace AbleSync.Core.Services
                     extractedProject.RelativePath = PathHelper.GetRelativePath(directoryInfo.FullName, root);
 
                     // TODO Transaction?
-                    var createdProject = await _projectRepository.CreateAsync(extractedProject, token);
-                    _fileTrackingService.CreateTrackingFile(createdProject.Id, directoryInfo);
-                    _logger.LogTrace($"A new tracking file has been created for project {createdProject.Id} at {directoryInfo.FullName}");
+                    var createdProjectId = await _projectRepository.CreateAsync(extractedProject, token);
+                    _fileTrackingService.CreateTrackingFile(createdProjectId, directoryInfo);
+                    _logger.LogTrace($"A new tracking file has been created for project {createdProjectId} at {directoryInfo.FullName}");
 
                     return;
                 }

--- a/AbleSync.Core/Services/ProjectTaskExecuterService.cs
+++ b/AbleSync.Core/Services/ProjectTaskExecuterService.cs
@@ -65,8 +65,8 @@ namespace AbleSync.Core.Services
 
             _logger.LogInformation($"Starting project task {task.Id} of type {task.ProjectTaskType}");
 
-            // This should be transactional --> scope?
-            var taskCreated = await _projectTaskRepository.CreateAsync(task, token);
+            // TODO This should be transactional --> scope?
+            var taskCreatedId = await _projectTaskRepository.CreateAsync(task, token);
 
             try
             {
@@ -77,7 +77,7 @@ namespace AbleSync.Core.Services
                     _ => throw new InvalidOperationException(nameof(task.ProjectTaskType)),
                 });
 
-                await _projectTaskRepository.MarkStatusAsync(taskCreated.Id, ProjectTaskStatus.Done, token);
+                await _projectTaskRepository.MarkStatusAsync(taskCreatedId, ProjectTaskStatus.Done, token);
 
                 _logger.LogInformation($"Finished project task {task.Id} of type {task.ProjectTaskType}");
             }

--- a/AbleSync.Core/Types/AudioFormat.cs
+++ b/AbleSync.Core/Types/AudioFormat.cs
@@ -8,16 +8,16 @@
         /// <summary>
         ///     .mp3 file format.
         /// </summary>
-        MP3,
+        Mp3 = 0,
 
         /// <summary>
         ///     .wav file format.
         /// </summary>
-        WAV,
+        Wav = 1,
 
         /// <summary>
         ///     .flac file format.
         /// </summary>
-        FLAC
+        Flac = 2
     }
 }

--- a/AbleSync.Infrastructure/Extensions/AbleSyncInfrastructureServiceCollectionExtensions.cs
+++ b/AbleSync.Infrastructure/Extensions/AbleSyncInfrastructureServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ namespace AbleSync.Infrastructure.Extensions
             services.AddScoped<DbProvider, NpgsqlDbProvider>();
 
             // Add repositories.
+            services.AddScoped<IAudioFileRepository, AudioFileRepository>();
             services.AddScoped<IProjectRepository, ProjectRepository>();
             services.AddScoped<IProjectTaskRepository, ProjectTaskRepository>();
 

--- a/AbleSync.Infrastructure/Provider/NpgsqlDbProvider.cs
+++ b/AbleSync.Infrastructure/Provider/NpgsqlDbProvider.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Npgsql;
-using Npgsql.TypeMapping;
 using System.Data.Common;
 
 namespace AbleSync.Infrastructure.Provider
@@ -26,6 +25,7 @@ namespace AbleSync.Infrastructure.Provider
         /// </summary>
         static NpgsqlDbProvider()
         {
+            NpgsqlConnection.GlobalTypeMapper.MapEnum<AudioFormat>("entities.audio_format");
             NpgsqlConnection.GlobalTypeMapper.MapEnum<ProjectStatus>("entities.project_status");
             NpgsqlConnection.GlobalTypeMapper.MapEnum<ProjectTaskStatus>("entities.project_task_status");
             NpgsqlConnection.GlobalTypeMapper.MapEnum<ProjectTaskType>("entities.project_task_type");

--- a/AbleSync.Infrastructure/Repositories/AudioFileRepository.cs
+++ b/AbleSync.Infrastructure/Repositories/AudioFileRepository.cs
@@ -1,0 +1,363 @@
+﻿using AbleSync.Core.Entities;
+using AbleSync.Core.Exceptions;
+using AbleSync.Core.Interfaces.Repositories;
+using AbleSync.Core.Types;
+using AbleSync.Infrastructure.Extensions;
+using AbleSync.Infrastructure.Provider;
+using RenameMe.Utility.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AbleSync.Infrastructure.Repositories
+{
+    /// <summary>
+    ///     Repository for audio files.
+    /// </summary>
+    internal sealed class AudioFileRepository : RepositoryBase<AudioFile>, IAudioFileRepository
+    {
+        /// <summary>
+        ///     Create new instance.
+        /// </summary>
+        public AudioFileRepository(DbProvider provider)
+            : base(provider)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a new <see cref="AudioFile"/> in our database.
+        /// </summary>
+        /// <param name="audioFile">The audioFile to create.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The created audioFile with id assigned.</returns>
+        public override async Task<Guid> CreateAsync(AudioFile audioFile, CancellationToken token)
+        {
+            if (audioFile == null)
+            {
+                throw new ArgumentNullException(nameof(audioFile));
+            }
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var sql = @"
+                INSERT INTO entities.audio_file (
+                            project_id,
+                            name,
+                            audio_format
+                )
+                VALUES (    @project_id,
+                            @name,
+                            @audio_format
+                )
+                RETURNING   id";
+
+            await using var connection = await _provider.OpenConnectionScopeAsync(token);
+            await using var command = _provider.CreateCommand(sql, connection);
+
+            MapToWriter(command, audioFile);
+
+            await using var reader = await command.ExecuteReaderAsyncEnsureRowAsync();
+            await reader.ReadAsync(token);
+
+            return reader.GetGuid(0);
+        }
+
+        // TODO Implement. Do we even want this functionality?
+        public override Task DeleteAsync(Guid id, CancellationToken token) => throw new NotImplementedException();
+
+        /// <summary>
+        ///     Checks if any audio files exist for a given 
+        ///     project id.
+        /// </summary>
+        /// <param name="projectId">The project id.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns><c>True</c> if any audio file exists.</returns>
+        public async Task<bool> ExistsAnyForProjectAsync(Guid projectId, CancellationToken token)
+        {
+            if (projectId == null || projectId == Guid.Empty)
+            {
+                throw new ArgumentNullException(nameof(projectId));
+            }
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var sql = @"
+                SELECT  count(*)
+                FROM    entities.audio_file
+                WHERE   project_id = @project_id";
+
+            await using var connection = await _provider.OpenConnectionScopeAsync(token);
+            await using var command = _provider.CreateCommand(sql, connection);
+
+            command.AddParameterWithValue("project_id", projectId);
+
+            var count = await command.ExecuteScalarUnsignedIntAsync(token);
+
+            return count > 0;
+        }
+
+        /// <summary>
+        ///     Checks if a <see cref="AudioFile"/> by a given <paramref name="id"/>
+        ///     exists in our database.
+        /// </summary>
+        /// <param name="id">The id to search for.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns><c>true</c> if the audioFile exists.</returns>
+        public override async Task<bool> ExistsAsync(Guid id, CancellationToken token)
+        {
+            if (id == null || id == Guid.Empty)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var sql = @"
+                SELECT  count(*)
+                FROM    entities.audio_file
+                WHERE   id = @id";
+
+            await using var connection = await _provider.OpenConnectionScopeAsync(token);
+            await using var command = _provider.CreateCommand(sql, connection);
+
+            command.AddParameterWithValue("id", id);
+
+            var count = await command.ExecuteScalarUnsignedIntAsync(token);
+            if (count > 1)
+            {
+                // FUTURE Custom exception for this?
+                throw new InvalidOperationException("Found more than one entity when looking for a single item");
+            }
+
+            return count == 1;
+        }
+
+        /// <summary>
+        ///     Checks if an audio file in a specific audio format
+        ///     exists for a given project id.
+        /// </summary>
+        /// <param name="projectId">The project id.</param>
+        /// <param name="audioFormat">The audio format to check for.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns><c>True</c> if an audio file exists.</returns>
+        public async Task<bool> ExistsForProjectAsync(Guid projectId, AudioFormat audioFormat, CancellationToken token)
+        {
+            if (projectId == null || projectId == Guid.Empty)
+            {
+                throw new ArgumentNullException(nameof(projectId));
+            }
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var sql = @"
+                SELECT  count(*)
+                FROM    entities.audio_file
+                WHERE   project_id = @project_id
+                AND     audio_format = @audio_format";
+
+            await using var connection = await _provider.OpenConnectionScopeAsync(token);
+            await using var command = _provider.CreateCommand(sql, connection);
+
+            command.AddParameterWithValue("project_id", projectId);
+            command.AddParameterWithValue("audio_format", audioFormat);
+
+            var count = await command.ExecuteScalarUnsignedIntAsync(token);
+
+            return count > 0;
+        }
+
+        // TODO Pagination?
+        /// <summary>
+        ///     Gets all projects from our database.
+        /// </summary>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>Collection of projects.</returns>
+        public override async IAsyncEnumerable<AudioFile> GetAllAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var sql = @"
+                SELECT  id,
+                        project_id,
+                        name,
+                        audio_format,
+                        date_created,
+                        date_updated,
+                        date_synced
+                FROM    entities.audio_file";
+
+            await using var connection = await _provider.OpenConnectionScopeAsync(token);
+            await using var command = _provider.CreateCommand(sql, connection);
+
+            await using var reader = await command.ExecuteReaderAsyncEnsureRowAsync();
+
+            while (await reader.ReadAsync(token))
+            {
+                yield return MapFromReader(reader);
+            }
+        }
+
+        /// <summary>
+        ///     Gets a single <see cref="AudioFile"/> from our database.
+        /// </summary>
+        /// <param name="id">Internal audioFile id.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns>The returned audioFile.</returns>
+        public override async Task<AudioFile> GetAsync(Guid id, CancellationToken token)
+        {
+            if (id == null || id == Guid.Empty)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var sql = @"
+                SELECT  id,
+                        project_id,
+                        name,
+                        audio_format,
+                        date_created,
+                        date_updated,
+                        date_synced
+                FROM    entities.audio_file
+                WHERE   id = @id
+                LIMIT   1";
+
+            await using var connection = await _provider.OpenConnectionScopeAsync(token);
+            await using var command = _provider.CreateCommand(sql, connection);
+
+            command.AddParameterWithValue("id", id);
+
+            await using var reader = await command.ExecuteReaderAsyncEnsureRowAsync();
+            await reader.ReadAsync(token);
+
+            return MapFromReader(reader);
+        }
+
+        /// <summary>
+        ///     Gets an audio file for a given project and a
+        ///     given audio format.
+        /// </summary>
+        /// <remarks>
+        ///     The audio file should exist or this will throw
+        ///     an exception.
+        /// </remarks>
+        /// <param name="projectId">The project id.</param>
+        /// <param name="audioFormat">The format to get.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The audio file for the project and format.</returns>
+        public async Task<AudioFile> GetFromProjectAsync(Guid projectId, AudioFormat audioFormat, CancellationToken token)
+        {
+            if (projectId == null || projectId == Guid.Empty)
+            {
+                throw new ArgumentNullException(nameof(projectId));
+            }
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var sql = @"
+                SELECT  id,
+                        project_id,
+                        name,
+                        audio_format,
+                        date_created,
+                        date_updated,
+                        date_synced
+                FROM    entities.audio_file
+                WHERE   project_id = @project_id
+                AND     audio_format = @audio_format
+                LIMIT   1";
+
+            await using var connection = await _provider.OpenConnectionScopeAsync(token);
+            await using var command = _provider.CreateCommand(sql, connection);
+
+            command.AddParameterWithValue("project_id", projectId);
+            command.AddParameterWithValue("audio_format", audioFormat);
+
+            await using var reader = await command.ExecuteReaderAsyncEnsureRowAsync();
+            await reader.ReadAsync(token);
+
+            return MapFromReader(reader);
+        }
+
+        /// <summary>
+        ///     Marks the sync date of an audio file as now.
+        /// </summary>
+        /// <param name="id">The audio file id.</param>
+        /// <param name="token">The cancellation token.</param>
+        public async Task MarkSyncedAsync(Guid id, CancellationToken token)
+        {
+            id.ThrowIfNullOrEmpty();
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var sql = @"
+                UPDATE  entities.audio_file
+                SET     date_synced = now()
+                WHERE   id = @id";
+
+            await using var connection = await _provider.OpenConnectionScopeAsync(token);
+            await using var command = _provider.CreateCommand(sql, connection);
+
+            command.AddParameterWithValue("id", id);
+
+            var affected = await command.ExecuteNonQueryAsync(token);
+            if (affected == 0)
+            {
+                throw new EntityNotFoundException(nameof(AudioFile));
+            }
+        }
+
+        public override Task UpdateAsync(AudioFile audioFile, CancellationToken token) => throw new NotImplementedException();
+
+        /// <summary>
+        ///     Maps from a <see cref="DbDataReader"/> to a <see cref="AudioFile"/>.
+        /// </summary>
+        /// <param name="reader">The reader to map from.</param>
+        /// <returns>The mapped audioFile.</returns>
+        private static AudioFile MapFromReader(DbDataReader reader)
+           => new AudioFile
+           {
+               Id = reader.GetGuid(0),
+               ProjectId = reader.GetGuid(1),
+               Name = reader.GetString(2),
+               AudioFormat = reader.GetFieldValue<AudioFormat>(3),
+               DateCreated = reader.GetDateTime(4),
+               DateUpdated = reader.GetSafeDateTime(5),
+               DateSynced = reader.GetDateTime(6)
+           };
+
+        /// <summary>
+        ///     Maps a <see cref="AudioFile"/> to a <see cref="DbCommand"/>.
+        /// </summary>
+        /// <param name="command">The command to write to.</param>
+        /// <param name="audioFile">The audioFile to write to the command.</param>
+        private static void MapToWriter(DbCommand command, AudioFile audioFile)
+        {
+            command.AddParameterWithValue("project_id", audioFile.ProjectId);
+            command.AddParameterWithValue("name", audioFile.Name);
+            command.AddParameterWithValue("audio_format", audioFile.AudioFormat);
+        }
+    }
+}

--- a/AbleSync.Infrastructure/Repositories/ProjectRepository.cs
+++ b/AbleSync.Infrastructure/Repositories/ProjectRepository.cs
@@ -17,7 +17,7 @@ namespace AbleSync.Infrastructure.Repositories
     /// <summary>
     ///     Repository for <see cref="Project"/> entities.
     /// </summary>
-    internal sealed class ProjectRepository : RepositoryBase, IProjectRepository
+    internal sealed class ProjectRepository : RepositoryBase<Project>, IProjectRepository
     {
         /// <summary>
         ///     Create new instance.
@@ -33,7 +33,7 @@ namespace AbleSync.Infrastructure.Repositories
         /// <param name="project">The project to create.</param>
         /// <param name="token">The cancellation token.</param>
         /// <returns>The created project with id assigned.</returns>
-        public async Task<Project> CreateAsync(Project project, CancellationToken token)
+        public override async Task<Guid> CreateAsync(Project project, CancellationToken token)
         {
             if (project == null)
             {
@@ -65,13 +65,11 @@ namespace AbleSync.Infrastructure.Repositories
             await using var reader = await command.ExecuteReaderAsyncEnsureRowAsync();
             await reader.ReadAsync(token);
 
-            var id = reader.GetGuid(0);
-
-            return await GetAsync(id, token);
+            return reader.GetGuid(0);
         }
 
         // TODO Implement. Do we even want this functionality?
-        public Task DeleteAsync(Guid id, CancellationToken token) => throw new NotImplementedException();
+        public override Task DeleteAsync(Guid id, CancellationToken token) => throw new NotImplementedException();
 
         /// <summary>
         ///     Checks if a <see cref="Project"/> by a given <paramref name="id"/>
@@ -80,7 +78,7 @@ namespace AbleSync.Infrastructure.Repositories
         /// <param name="id">The id to search for.</param>
         /// <param name="token">Cancellation token.</param>
         /// <returns><c>true</c> if the project exists.</returns>
-        public async Task<bool> ExistsAsync(Guid id, CancellationToken token)
+        public override async Task<bool> ExistsAsync(Guid id, CancellationToken token)
         {
             if (id == null || id == Guid.Empty)
             {
@@ -117,7 +115,7 @@ namespace AbleSync.Infrastructure.Repositories
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>Collection of projects.</returns>
-        public async IAsyncEnumerable<Project> GetAllAsync([EnumeratorCancellation] CancellationToken token)
+        public override async IAsyncEnumerable<Project> GetAllAsync([EnumeratorCancellation] CancellationToken token)
         {
             if (token == null)
             {
@@ -151,7 +149,7 @@ namespace AbleSync.Infrastructure.Repositories
         /// <param name="id">Internal project id.</param>
         /// <param name="token">Cancellation token.</param>
         /// <returns>The returned project.</returns>
-        public async Task<Project> GetAsync(Guid id, CancellationToken token)
+        public override async Task<Project> GetAsync(Guid id, CancellationToken token)
         {
             if (id == null || id == Guid.Empty)
             {
@@ -260,7 +258,7 @@ namespace AbleSync.Infrastructure.Repositories
             return await GetAsync(id, token);
         }
 
-        public Task<Project> UpdateAsync(Project project, CancellationToken token)
+        public override Task UpdateAsync(Project project, CancellationToken token)
             => throw new NotImplementedException();
 
         /// <summary>

--- a/AbleSync.Infrastructure/Repositories/ProjectTaskRepository.cs
+++ b/AbleSync.Infrastructure/Repositories/ProjectTaskRepository.cs
@@ -16,7 +16,7 @@ namespace AbleSync.Infrastructure.Repositories
     /// <summary>
     ///     Repository for <see cref="ProjectTask"/> entities.
     /// </summary>
-    internal sealed class ProjectTaskRepository : RepositoryBase, IProjectTaskRepository
+    internal sealed class ProjectTaskRepository : RepositoryBase<ProjectTask>, IProjectTaskRepository
     {
         /// <summary>
         ///     Create new instance.
@@ -32,7 +32,7 @@ namespace AbleSync.Infrastructure.Repositories
         /// <param name="projectTask">See <see cref="Project"/>.</param>
         /// <param name="token">The cancellation token.</param>
         /// <returns>The created <see cref="ProjectTask"/>.</returns>
-        public async Task<ProjectTask> CreateAsync(ProjectTask projectTask, CancellationToken token)
+        public override async Task<Guid> CreateAsync(ProjectTask projectTask, CancellationToken token)
         {
             if (projectTask == null)
             {
@@ -66,10 +66,12 @@ namespace AbleSync.Infrastructure.Repositories
             await using var reader = await command.ExecuteReaderAsyncEnsureRowAsync();
             await reader.ReadAsync(token);
 
-            var id = reader.GetGuid(0);
-
-            return await GetAsync(id, token);
+            return reader.GetGuid(0);
         }
+
+        public override Task DeleteAsync(Guid id, CancellationToken token) => throw new NotImplementedException();
+
+        public override Task<bool> ExistsAsync(Guid id, CancellationToken token) => throw new NotImplementedException();
 
         // TODO Make async enumerable?
         /// <summary>
@@ -120,7 +122,7 @@ namespace AbleSync.Infrastructure.Repositories
         /// <param name="id">Internal project id.</param>
         /// <param name="token">The cancellation token.</param>
         /// <returns>The returned <see cref="ProjectTask"/>.</returns>
-        public async Task<ProjectTask> GetAsync(Guid id, CancellationToken token)
+        public override async Task<ProjectTask> GetAsync(Guid id, CancellationToken token)
         {
             if (id == null || id == Guid.Empty)
             {
@@ -195,29 +197,11 @@ namespace AbleSync.Infrastructure.Repositories
         }
 
         /// <summary>
-        ///     Maps from a <see cref="DbDataReader"/> to a <see cref="ProjectTask"/>.
-        /// </summary>
-        /// <param name="reader">The reader to map from.</param>
-        /// <returns>The mapped project.</returns>
-        private static ProjectTask MapFromReader(DbDataReader reader)
-           => new ProjectTask
-           {
-               Id = reader.GetGuid(0),
-               ProjectId = reader.GetGuid(1),
-               DateCreated = reader.GetDateTime(2),
-               DateUpdated = reader.GetSafeDateTime(3),
-               DateCompleted = reader.GetSafeDateTime(4),
-               ProjectTaskStatus = reader.GetFieldValue<ProjectTaskStatus>(5),
-               ProjectTaskType = reader.GetFieldValue<ProjectTaskType>(6),
-               TaskParameter = reader.GetSafeString(7),
-           };
-
-        /// <summary>
         ///     Gets all project tasks from our database.
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>Collection of project tasks.</returns>
-        public async IAsyncEnumerable<ProjectTask> GetAllAsync([EnumeratorCancellation] CancellationToken token)
+        public override async IAsyncEnumerable<ProjectTask> GetAllAsync([EnumeratorCancellation] CancellationToken token)
         {
             if (token == null)
             {
@@ -245,5 +229,26 @@ namespace AbleSync.Infrastructure.Repositories
                 yield return MapFromReader(reader);
             }
         }
+
+        public override Task UpdateAsync(ProjectTask entity, CancellationToken token) => throw new NotImplementedException();
+
+        /// <summary>
+        ///     Maps from a <see cref="DbDataReader"/> to a <see cref="ProjectTask"/>.
+        /// </summary>
+        /// <param name="reader">The reader to map from.</param>
+        /// <returns>The mapped project.</returns>
+        private static ProjectTask MapFromReader(DbDataReader reader)
+           => new ProjectTask
+           {
+               Id = reader.GetGuid(0),
+               ProjectId = reader.GetGuid(1),
+               DateCreated = reader.GetDateTime(2),
+               DateUpdated = reader.GetSafeDateTime(3),
+               DateCompleted = reader.GetSafeDateTime(4),
+               ProjectTaskStatus = reader.GetFieldValue<ProjectTaskStatus>(5),
+               ProjectTaskType = reader.GetFieldValue<ProjectTaskType>(6),
+               TaskParameter = reader.GetSafeString(7),
+           };
+
     }
 }

--- a/AbleSync.Infrastructure/Repositories/RepositoryBase.cs
+++ b/AbleSync.Infrastructure/Repositories/RepositoryBase.cs
@@ -1,24 +1,100 @@
-﻿using AbleSync.Infrastructure.Provider;
-using Npgsql;
+﻿using AbleSync.Core.Entities;
+using AbleSync.Core.Interfaces.Repositories;
+using AbleSync.Infrastructure.Provider;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AbleSync.Infrastructure.Repositories
 {
+    // Implementations of the repo base have a lot of duplicate code.
     /// <summary>
     ///     Base class for all repositories.
     /// </summary>
-    internal abstract class RepositoryBase
+    internal abstract class RepositoryBase<TEntity> : IRepositoryBaseCRUD<TEntity>
+        where TEntity : EntityBase
     {
         protected DbProvider _provider;
 
         /// <summary>
         ///     Create new instance.
         /// </summary>
-        public RepositoryBase(DbProvider provider)
+        public RepositoryBase(DbProvider provider) => _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+
+        /// <summary>
+        ///     Creates an entity in our data store and returns
+        ///     the id of the created entity.
+        /// </summary>
+        /// <param name="entity">The entity to create.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The created entity id.</returns>
+        public abstract Task<Guid> CreateAsync(TEntity entity, CancellationToken token);
+
+        /// <summary>
+        ///     Creates an entity and fetched it from the data store afterwards.
+        ///     This calls <see cref="CreateGetAsync(TEntity, CancellationToken)"/>,
+        ///     then calls <see cref="GetAsync(Guid, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="entity">The entity to create.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The created entity fetched from the data store.</returns>
+        public virtual async Task<TEntity> CreateGetAsync(TEntity entity, CancellationToken token)
         {
-            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            var id = await CreateAsync(entity, token);
+            return await GetAsync(id, token);
+        }
+
+        /// <summary>
+        ///     Deletes an entity from our data store.
+        /// </summary>
+        /// <param name="id">Internal entity id.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>See <see cref="Task"/>.</returns>
+        public abstract Task DeleteAsync(Guid id, CancellationToken token);
+
+        /// <summary>
+        ///     Checks if a given entity exists in our data store.
+        /// </summary>
+        /// <param name="id">Internal enitity id.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns><c>true</c> if the entity exists.</returns>
+        public abstract Task<bool> ExistsAsync(Guid id, CancellationToken token);
+
+        /// <summary>
+        ///     Gets all entities from our data store.
+        /// </summary>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>Collection of entities.</returns>
+        public abstract IAsyncEnumerable<TEntity> GetAllAsync(CancellationToken token);
+
+        /// <summary>
+        ///     Gets an entity from our data store.
+        /// </summary>
+        /// <param name="id">Internal entity id.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The returned entity.</returns>
+        public abstract Task<TEntity> GetAsync(Guid id, CancellationToken token);
+
+        /// <summary>
+        ///     Updates an entity in our data store.
+        /// </summary>
+        /// <param name="entity">The new to-update entity.</param>
+        /// <param name="token">The cancellation token.</param>
+        public abstract Task UpdateAsync(TEntity entity, CancellationToken token);
+
+        /// <summary>
+        ///     Updates an entity and fetches it from the data store afterwards.
+        ///     This calls <see cref="UpdateAsync(TEntity, CancellationToken)"/>,
+        ///     then calls <see cref="GetAsync(Guid, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="entity">The entity with updated parameters.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The updated entity fetched from the data store.</returns>
+        public virtual async Task<TEntity> UpdateGetAsync(TEntity entity, CancellationToken token)
+        {
+            await UpdateAsync(entity, token);
+            return await GetAsync(entity.Id, token);
         }
     }
 }


### PR DESCRIPTION
This fixes:
#17 
#28 
#34 

Audio files are now stored in the db and blob storage based on an assigned id. Repositories have also been cleaned up.

Services now also work based on ids instead of entity objects, and will query repositories to get required entities.